### PR TITLE
Add missing "http://" on some assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
 
         <title class="trans">Respect - Simple independent components for building or improving PHP applications</title>
 
-        <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css">
-        <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap-theme.min.css">
+        <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css">
+        <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap-theme.min.css">
         <link rel="stylesheet" href="assets/css/style.css">
 
     </head>


### PR DESCRIPTION
There is no need to keep it since the website works on GitHub pages which have no HTTPS support.
Also, the entire website is just in one single file but because of that we need to start an HTTP server to work on it.